### PR TITLE
Add TLS support to Dialer and Listener with configuration options

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -2,6 +2,7 @@ package revdial
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"net"
@@ -26,6 +27,7 @@ type Dialer struct {
 	serverOpts []proto.ServerOption
 	wg         sync.WaitGroup
 	mu         sync.RWMutex
+	tlsConfig  *tls.Config
 }
 
 type DialerOption func(*Dialer)
@@ -50,7 +52,15 @@ func (d *Dialer) Start(ctx context.Context) error {
 
 	ctx, d.cancel = context.WithCancel(ctx)
 
-	l, err := net.Listen("tcp", d.listen)
+	var l net.Listener
+	var err error
+
+	if d.tlsConfig != nil {
+		l, err = tls.Listen("tcp", d.listen, d.tlsConfig)
+	} else {
+		l, err = net.Listen("tcp", d.listen)
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
@@ -191,5 +201,14 @@ func (d *Dialer) removeRequest(id uuid.UUID) *connRequest {
 func WithUserPassAuth(auth func(username, password string) bool) DialerOption {
 	return func(d *Dialer) {
 		d.serverOpts = append(d.serverOpts, proto.WithUserPassAuth(auth))
+	}
+}
+
+// WithDialerTLSConfig configures the Dialer with TLS settings.
+// It takes a tls.Config pointer and returns a DialerOption that applies the TLS configuration.
+// If this option is not provided, the connection will be unencrypted.
+func WithDialerTLSConfig(config *tls.Config) DialerOption {
+	return func(d *Dialer) {
+		d.tlsConfig = config.Clone() // Clone to prevent external modifications
 	}
 }

--- a/dialer.go
+++ b/dialer.go
@@ -23,11 +23,11 @@ type Dialer struct {
 	cancel     context.CancelFunc
 	cm         *connmng.ConnManager
 	requests   map[uuid.UUID]*connRequest
+	tlsConfig  *tls.Config
 	listen     string
 	serverOpts []proto.ServerOption
 	wg         sync.WaitGroup
 	mu         sync.RWMutex
-	tlsConfig  *tls.Config
 }
 
 type DialerOption func(*Dialer)
@@ -52,8 +52,10 @@ func (d *Dialer) Start(ctx context.Context) error {
 
 	ctx, d.cancel = context.WithCancel(ctx)
 
-	var l net.Listener
-	var err error
+	var (
+		l   net.Listener
+		err error
+	)
 
 	if d.tlsConfig != nil {
 		l, err = tls.Listen("tcp", d.listen, d.tlsConfig)

--- a/example_test.go
+++ b/example_test.go
@@ -2,6 +2,8 @@ package revdial
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"log"
 )
 
@@ -40,6 +42,151 @@ func ExampleDialer() {
 		return
 	}
 
+	conn.Close()
+
+	// Output:
+}
+
+//nolint:errcheck // ignore errors in example for readability purposes
+func ExampleDialer_withTLS() {
+	// In a real application, you would load certificates from files
+	// For this example, we're using variables to represent the certificates
+	var (
+		serverCert tls.Certificate // Server's certificate and private key
+		clientCert tls.Certificate // Client's certificate and private key
+		caCertPool *x509.CertPool  // Pool of trusted CA certificates
+	)
+
+	// Configure TLS for the Dialer (server)
+	serverTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    caCertPool,
+		MinVersion:   tls.VersionTLS12, // Require TLS 1.2 or higher
+	}
+
+	// Configure TLS for the Listener (client)
+	clientTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      caCertPool,
+		MinVersion:   tls.VersionTLS12,
+		ServerName:   "example.com", // Must match the server certificate's DNS names
+	}
+
+	ctx := context.Background()
+
+	// Create and start the Dialer with TLS
+	dialer := NewDialer(":0", WithDialerTLSConfig(serverTLSConfig))
+	if err := dialer.Start(ctx); err != nil {
+		log.Fatalf("failed to start dialer: %v", err)
+	}
+	defer dialer.Stop()
+
+	// Create the Listener with TLS
+	listener, err := Listen(context.Background(), dialer.Addr(),
+		WithListenerTLSConfig(clientTLSConfig))
+	if err != nil {
+		log.Printf("failed to create listener: %v", err)
+		return
+	}
+	defer listener.Close()
+
+	// Accept connections in a goroutine
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Printf("failed to accept connection: %v", err)
+			return
+		}
+		// The connection is now encrypted with TLS
+		// Here you can safely transmit sensitive data
+		conn.Close()
+	}()
+
+	// Dial using the secure connection
+	conn, err := dialer.DialContext(ctx)
+	if err != nil {
+		log.Printf("failed to dial: %v", err)
+		return
+	}
+	conn.Close()
+
+	// Output:
+}
+
+//nolint:errcheck // ignore errors in example for readability purposes
+func ExampleDialer_withTLSAndAuth() {
+	// TLS configuration (as in the previous example)
+	var (
+		serverCert tls.Certificate
+		clientCert tls.Certificate
+		caCertPool *x509.CertPool
+	)
+
+	serverTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    caCertPool,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	clientTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      caCertPool,
+		MinVersion:   tls.VersionTLS12,
+		ServerName:   "example.com",
+	}
+
+	ctx := context.Background()
+
+	// Create and start the Dialer with both TLS and authentication
+	authFunc := func(username, password string) bool {
+		// In a real application, validate credentials against a secure store
+		return username == "admin" && password == "secret"
+	}
+
+	dialer := NewDialer(":0",
+		WithDialerTLSConfig(serverTLSConfig),
+		WithUserPassAuth(authFunc))
+
+	if err := dialer.Start(ctx); err != nil {
+		log.Fatalf("failed to start dialer: %v", err)
+	}
+	defer dialer.Stop()
+
+	// Create the Listener with both TLS and authentication
+	authOpt, err := WithUserPass("admin", "secret")
+	if err != nil {
+		log.Printf("failed to create auth option: %v", err)
+		return
+	}
+
+	listener, err := Listen(context.Background(), dialer.Addr(),
+		WithListenerTLSConfig(clientTLSConfig),
+		authOpt)
+	if err != nil {
+		log.Printf("failed to create listener: %v", err)
+		return
+	}
+	defer listener.Close()
+
+	// Accept connections in a goroutine
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Printf("failed to accept connection: %v", err)
+			return
+		}
+		// Connection is now both encrypted and authenticated
+		conn.Close()
+	}()
+
+	// Dial using the secure and authenticated connection
+	conn, err := dialer.DialContext(ctx)
+	if err != nil {
+		log.Printf("failed to dial: %v", err)
+		return
+	}
 	conn.Close()
 
 	// Output:

--- a/example_test.go
+++ b/example_test.go
@@ -109,6 +109,7 @@ func ExampleDialer_withTLS() {
 		log.Printf("failed to dial: %v", err)
 		return
 	}
+
 	conn.Close()
 
 	// Output:
@@ -187,6 +188,7 @@ func ExampleDialer_withTLSAndAuth() {
 		log.Printf("failed to dial: %v", err)
 		return
 	}
+
 	conn.Close()
 
 	// Output:

--- a/listener.go
+++ b/listener.go
@@ -14,12 +14,12 @@ var ErrListenerClosed = fmt.Errorf("listener closed")
 
 type Listener struct {
 	ctx        context.Context
+	addr       net.Addr
 	cancel     context.CancelFunc
 	client     *proto.Client
 	dialer     *net.Dialer
-	addr       net.Addr
-	clientOpts []proto.ClientOption
 	tlsConfig  *tls.Config
+	clientOpts []proto.ClientOption
 }
 
 type ListenerOption func(*Listener)
@@ -53,8 +53,10 @@ func Listen(ctx context.Context, dialerSrv string, opts ...ListenerOption) (*Lis
 		if err := tlsConn.Handshake(); err != nil {
 			conn.Close()
 			l.cancel()
+
 			return nil, fmt.Errorf("TLS handshake failed: %w", err)
 		}
+
 		conn = tlsConn
 	}
 
@@ -91,6 +93,7 @@ func (l *Listener) Accept() (net.Conn, error) {
 				conn.Close()
 				return nil, fmt.Errorf("TLS handshake failed: %w", err)
 			}
+
 			conn = tlsConn
 		}
 

--- a/listener.go
+++ b/listener.go
@@ -2,6 +2,7 @@ package revdial
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 
@@ -18,6 +19,7 @@ type Listener struct {
 	dialer     *net.Dialer
 	addr       net.Addr
 	clientOpts []proto.ClientOption
+	tlsConfig  *tls.Config
 }
 
 type ListenerOption func(*Listener)
@@ -46,6 +48,16 @@ func Listen(ctx context.Context, dialerSrv string, opts ...ListenerOption) (*Lis
 		return nil, fmt.Errorf("failed to connect to dialler server: %w", err)
 	}
 
+	if l.tlsConfig != nil {
+		tlsConn := tls.Client(conn, l.tlsConfig)
+		if err := tlsConn.Handshake(); err != nil {
+			conn.Close()
+			l.cancel()
+			return nil, fmt.Errorf("TLS handshake failed: %w", err)
+		}
+		conn = tlsConn
+	}
+
 	l.client = proto.NewClient(conn, l.clientOpts...)
 
 	err = l.client.Register(l.ctx, uuid.New())
@@ -71,6 +83,15 @@ func (l *Listener) Accept() (net.Conn, error) {
 		if err != nil {
 			l.cancel()
 			return nil, fmt.Errorf("failed to connect to dialler server: %w", err)
+		}
+
+		if l.tlsConfig != nil {
+			tlsConn := tls.Client(conn, l.tlsConfig)
+			if err := tlsConn.Handshake(); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("TLS handshake failed: %w", err)
+			}
+			conn = tlsConn
 		}
 
 		client := proto.NewClient(conn, l.clientOpts...)
@@ -109,4 +130,13 @@ func WithUserPass(username, password string) (ListenerOption, error) {
 	return func(l *Listener) {
 		l.clientOpts = append(l.clientOpts, opt)
 	}, nil
+}
+
+// WithListenerTLSConfig configures a Listener with TLS settings.
+// It takes a tls.Config pointer and returns a ListenerOption that applies the TLS configuration.
+// If this option is not provided, the connection will be unencrypted.
+func WithListenerTLSConfig(config *tls.Config) ListenerOption {
+	return func(l *Listener) {
+		l.tlsConfig = config.Clone() // Clone to prevent external modifications
+	}
 }

--- a/revdial_int_test.go
+++ b/revdial_int_test.go
@@ -188,7 +188,8 @@ func TestListenerDialer_WithTLS_Success(t *testing.T) {
 	dialer := NewDialer(":0", WithDialerTLSConfig(serverTLSConfig))
 
 	require.NoError(t, dialer.Start(ctx), "Failed to start dialer")
-	defer dialer.Stop()
+
+	defer func() { _ = dialer.Stop() }()
 
 	addr := dialer.listener.Addr().String()
 
@@ -249,7 +250,8 @@ func TestListenerDialer_WithTLS_InvalidCert(t *testing.T) {
 	dialer := NewDialer(":0", WithDialerTLSConfig(serverTLSConfig))
 
 	require.NoError(t, dialer.Start(ctx), "Failed to start dialer")
-	defer dialer.Stop()
+
+	defer func() { _ = dialer.Stop() }()
 
 	addr := dialer.listener.Addr().String()
 
@@ -257,6 +259,7 @@ func TestListenerDialer_WithTLS_InvalidCert(t *testing.T) {
 	listener, err := Listen(ctx, addr, WithListenerTLSConfig(clientTLSConfig))
 	// Should fail due to invalid certificate
 	require.Error(t, err, "Expected error due to invalid certificate")
+
 	if listener != nil {
 		listener.Close()
 	}
@@ -293,7 +296,8 @@ func TestListenerDialer_WithTLSAndAuth_Success(t *testing.T) {
 		}))
 
 	require.NoError(t, dialer.Start(ctx), "Failed to start dialer")
-	defer dialer.Stop()
+
+	defer func() { _ = dialer.Stop() }()
 
 	addr := dialer.listener.Addr().String()
 

--- a/revdial_int_test.go
+++ b/revdial_int_test.go
@@ -2,11 +2,61 @@ package revdial
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// generateTestCert creates a test certificate and private key for testing TLS
+func generateTestCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+
+	// Generate private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "Failed to generate private key")
+
+	// Generate self-signed certificate
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test Org"},
+		},
+		DNSNames:              []string{"localhost", "example.com"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err, "Failed to create certificate")
+
+	// Create certificate pool
+	certPool := x509.NewCertPool()
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err, "Failed to parse certificate")
+	certPool.AddCert(cert)
+
+	// Create tls.Certificate
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  privateKey,
+		Leaf:        cert,
+	}
+
+	return tlsCert, certPool
+}
 
 func TestListenerDialer(t *testing.T) {
 	// Create a new dialer
@@ -102,6 +152,176 @@ func TestListenerDialer_WithUserPassAuth_Success(t *testing.T) {
 		t.Fatalf("failed to dial: %v", err)
 	}
 
+	defer conn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("expected connection to be accepted")
+	}
+}
+
+func TestListenerDialer_WithTLS_Success(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Generate test certificates
+	cert, certPool := generateTestCert(t)
+
+	// Configure TLS for server (dialer)
+	serverTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    certPool,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	// Configure TLS for client (listener)
+	clientTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      certPool,
+		ServerName:   "example.com",
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	// Create a new dialer with TLS
+	dialer := NewDialer(":0", WithDialerTLSConfig(serverTLSConfig))
+
+	require.NoError(t, dialer.Start(ctx), "Failed to start dialer")
+	defer dialer.Stop()
+
+	addr := dialer.listener.Addr().String()
+
+	// Create a new listener with TLS
+	listener, err := Listen(ctx, addr, WithListenerTLSConfig(clientTLSConfig))
+	require.NoError(t, err, "Failed to create listener")
+	defer listener.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		conn, err := listener.Accept()
+		if err != nil {
+			t.Errorf("failed to accept connection: %v", err)
+			cancel()
+		} else {
+			conn.Close()
+		}
+	}()
+
+	conn, err := dialer.DialContext(ctx)
+	require.NoError(t, err, "Failed to dial")
+	defer conn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("expected connection to be accepted")
+	}
+}
+
+func TestListenerDialer_WithTLS_InvalidCert(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Generate two different certificates
+	cert1, certPool1 := generateTestCert(t)
+	cert2, _ := generateTestCert(t)
+
+	// Configure TLS for server (dialer) with cert1
+	serverTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert1},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    certPool1,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	// Configure TLS for client (listener) with cert2 (untrusted)
+	clientTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert2},
+		RootCAs:      certPool1,
+		ServerName:   "example.com",
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	// Create a new dialer with TLS
+	dialer := NewDialer(":0", WithDialerTLSConfig(serverTLSConfig))
+
+	require.NoError(t, dialer.Start(ctx), "Failed to start dialer")
+	defer dialer.Stop()
+
+	addr := dialer.listener.Addr().String()
+
+	// Create a new listener with TLS
+	listener, err := Listen(ctx, addr, WithListenerTLSConfig(clientTLSConfig))
+	// Should fail due to invalid certificate
+	require.Error(t, err, "Expected error due to invalid certificate")
+	if listener != nil {
+		listener.Close()
+	}
+}
+
+func TestListenerDialer_WithTLSAndAuth_Success(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Generate test certificates
+	cert, certPool := generateTestCert(t)
+
+	// Configure TLS for server (dialer)
+	serverTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    certPool,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	// Configure TLS for client (listener)
+	clientTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      certPool,
+		ServerName:   "example.com",
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	// Create a new dialer with TLS and auth
+	dialer := NewDialer(":0",
+		WithDialerTLSConfig(serverTLSConfig),
+		WithUserPassAuth(func(user, pass string) bool {
+			return user == "user" && pass == "pass"
+		}))
+
+	require.NoError(t, dialer.Start(ctx), "Failed to start dialer")
+	defer dialer.Stop()
+
+	addr := dialer.listener.Addr().String()
+
+	authOpt, err := WithUserPass("user", "pass")
+	require.NoError(t, err, "Failed to create auth option")
+
+	// Create a new listener with TLS and auth
+	listener, err := Listen(ctx, addr,
+		WithListenerTLSConfig(clientTLSConfig),
+		authOpt)
+	require.NoError(t, err, "Failed to create listener")
+	defer listener.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		conn, err := listener.Accept()
+		if err != nil {
+			t.Errorf("failed to accept connection: %v", err)
+			cancel()
+		} else {
+			conn.Close()
+		}
+	}()
+
+	conn, err := dialer.DialContext(ctx)
+	require.NoError(t, err, "Failed to dial")
 	defer conn.Close()
 
 	select {


### PR DESCRIPTION
Introduce TLS configuration options for both the Dialer and Listener, enabling secure connections. This update includes example usage for establishing encrypted and authenticated communication.