### PR TITLE
Add ping handling for client-server communication

### DIFF
--- a/proto/client.go
+++ b/proto/client.go
@@ -284,6 +284,9 @@ func (c *Client) handleConnect(ctx context.Context) error {
 	return nil
 }
 
+// handlePing sends a ping response to the connected client.
+// It writes a success response using the connection.
+// It returns an error if writing to the connection fails.
 func (c *Client) handlePing() error {
 	if _, err := c.conn.Write([]byte{versionV1, resSuccess}); err != nil {
 		return fmt.Errorf("failed to write ping response: %w", err)

--- a/proto/client.go
+++ b/proto/client.go
@@ -245,6 +245,8 @@ func (c *Client) handleCommand(ctx context.Context) error {
 	switch msg {
 	case cmdConnect:
 		return c.handleConnect(ctx)
+	case cmdPing:
+		return c.handlePing()
 	default:
 		return fmt.Errorf("unsupported command: %d", msg)
 	}
@@ -277,6 +279,14 @@ func (c *Client) handleConnect(ctx context.Context) error {
 
 	if _, err := c.conn.Write([]byte{versionV1, resSuccess}); err != nil {
 		return fmt.Errorf("failed to write connect response: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Client) handlePing() error {
+	if _, err := c.conn.Write([]byte{versionV1, resSuccess}); err != nil {
+		return fmt.Errorf("failed to write ping response: %w", err)
 	}
 
 	return nil

--- a/proto/proto_int_test.go
+++ b/proto/proto_int_test.go
@@ -292,3 +292,36 @@ func TestRegister_WithUserPassAuth_IncorrectPass(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 }
+
+func TestPing_Success(t *testing.T) {
+	conn1, conn2 := net.Pipe()
+
+	client := NewClient(conn1)
+	defer client.Close()
+
+	server := NewServer(conn2)
+	defer server.Close()
+
+	done := make(chan struct{})
+	go func() {
+		err := server.Process()
+		assert.NoError(t, err)
+		assert.Equal(t, server.State(), StateRegistered, "expected server to be in registered state")
+
+		close(done)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err := client.Register(ctx, uuid.New())
+	assert.NoError(t, err)
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	err = server.SendPingCommand()
+	assert.NoError(t, err)
+}

--- a/proto/proto_int_test.go
+++ b/proto/proto_int_test.go
@@ -14,10 +14,10 @@ func TestRegister_Success(t *testing.T) {
 	conn1, conn2 := net.Pipe()
 
 	client := NewClient(conn1)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	server := NewServer(conn2)
-	defer server.Close()
+	defer func() { _ = server.Close() }()
 
 	done := make(chan struct{})
 	go func() {
@@ -44,10 +44,10 @@ func TestRegister_Success(t *testing.T) {
 func TestRegister_Failure(t *testing.T) {
 	conn1, conn2 := net.Pipe()
 
-	defer conn2.Close()
+	defer func() { _ = conn2.Close() }()
 
 	client := NewClient(conn1)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	done := make(chan struct{})
 	go func() {
@@ -81,10 +81,10 @@ func TestSendCommand(t *testing.T) {
 	conn1, conn2 := net.Pipe()
 
 	client := NewClient(conn1)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	server := NewServer(conn2)
-	defer server.Close()
+	defer func() { _ = server.Close() }()
 
 	done := make(chan struct{})
 	go func() {
@@ -123,10 +123,10 @@ func TestSendCommand_Failure(t *testing.T) {
 	conn1, conn2 := net.Pipe()
 
 	client := NewClient(conn1)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	server := NewServer(conn2)
-	defer server.Close()
+	defer func() { _ = server.Close() }()
 
 	done := make(chan struct{})
 	go func() {
@@ -167,10 +167,10 @@ func TestBind_Success(t *testing.T) {
 	conn1, conn2 := net.Pipe()
 
 	client := NewClient(conn1)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	server := NewServer(conn2)
-	defer server.Close()
+	defer func() { _ = server.Close() }()
 
 	done := make(chan struct{})
 	go func() {
@@ -194,10 +194,10 @@ func TestBind_Success(t *testing.T) {
 
 func TestBind_Failure(t *testing.T) {
 	conn1, conn2 := net.Pipe()
-	defer conn2.Close()
+	defer func() { _ = conn2.Close() }()
 
 	client := NewClient(conn1)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	done := make(chan struct{})
 	go func() {
@@ -230,12 +230,12 @@ func TestRegister_WithUserPassAuth_Success(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := NewClient(conn1, clientOpt)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	server := NewServer(conn2, WithUserPassAuth(func(user, pass string) bool {
 		return user == "user" && pass == "pass"
 	}))
-	defer server.Close()
+	defer func() { _ = server.Close() }()
 
 	done := make(chan struct{})
 	go func() {
@@ -266,12 +266,12 @@ func TestRegister_WithUserPassAuth_IncorrectPass(t *testing.T) {
 	assert.NoError(t, err)
 
 	client := NewClient(conn1, clientOpt)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	server := NewServer(conn2, WithUserPassAuth(func(user, pass string) bool {
 		return user == "user" && pass == "pass"
 	}))
-	defer server.Close()
+	defer func() { _ = server.Close() }()
 
 	done := make(chan struct{})
 	go func() {
@@ -297,10 +297,10 @@ func TestPing_Success(t *testing.T) {
 	conn1, conn2 := net.Pipe()
 
 	client := NewClient(conn1)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	server := NewServer(conn2)
-	defer server.Close()
+	defer func() { _ = server.Close() }()
 
 	done := make(chan struct{})
 	go func() {

--- a/proto/server.go
+++ b/proto/server.go
@@ -109,6 +109,9 @@ func (s *Server) SendConnectCommand(id uuid.UUID) error {
 	return nil
 }
 
+// SendPingCommand sends a ping command to the server to verify connectivity.
+// It returns nil if the server responds successfully or an error if the operation fails.
+// An error is returned if the server is not in the registered state, the request fails, or the response is unsuccessful.
 func (s *Server) SendPingCommand() error {
 	if s.state.Load() != int32(StateRegistered) {
 		return fmt.Errorf("unexpected state: %d", s.state.Load())

--- a/proto/server.go
+++ b/proto/server.go
@@ -109,6 +109,26 @@ func (s *Server) SendConnectCommand(id uuid.UUID) error {
 	return nil
 }
 
+func (s *Server) SendPingCommand() error {
+	if s.state.Load() != int32(StateRegistered) {
+		return fmt.Errorf("unexpected state: %d", s.state.Load())
+	}
+
+	req := make([]byte, 0, 17)
+	req = append(req, cmdPing)
+
+	resp, err := sendRequest(s.conn, req)
+	if err != nil {
+		return fmt.Errorf("failed to send ping command: %w", err)
+	}
+
+	if resp != resSuccess {
+		return fmt.Errorf("failed to ping: %d", resp)
+	}
+
+	return nil
+}
+
 // Close closes the server connection and updates the server state to "Disconnected".
 // It returns an error if there was a problem closing the connection.
 func (s *Server) Close() error {

--- a/proto/static.go
+++ b/proto/static.go
@@ -14,6 +14,7 @@ const (
 	cmdRegister byte = 1
 	cmdConnect  byte = 2
 	cmdBind     byte = 3
+	cmdPing     byte = 4
 )
 
 const (


### PR DESCRIPTION
### Description

This pull request introduces support for ping handling in both client and server-side logic to facilitate better connectivity and error handling. 

Key changes include:
- Added `handlePing` method to the client for responding to ping commands.
- Added `SendPingCommand` method to the server to initiate and verify connectivity pings.
- Updated protocol to include ping command handling.
- Added a test case to validate successful ping interactions.

These changes ensure robust communication between the client and server during ping operations. 
