### PR TITLE
Add state management for Client and Server lifecycle handling

### DIFF
--- a/proto/client.go
+++ b/proto/client.go
@@ -14,6 +14,16 @@ type ClientConnect struct {
 	ID uuid.UUID
 }
 
+type clientState int8
+
+const (
+	connected clientState = iota
+	processing
+	registered
+	bound
+	disconnected
+)
+
 type Client struct {
 	conn     io.ReadWriteCloser
 	cancel   context.CancelFunc
@@ -21,6 +31,8 @@ type Client struct {
 	token    []byte
 	wg       sync.WaitGroup
 	authMode byte
+	mu       sync.Mutex
+	state    clientState
 }
 
 type ClientOption func(*Client)
@@ -51,6 +63,15 @@ func (c *Client) Commands() <-chan ClientConnect {
 // It takes a context.Context as a parameter and returns an error.
 // The Register method establishes a connection with the server and handles the registration process.
 func (c *Client) Register(ctx context.Context, id uuid.UUID) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.state != connected {
+		return fmt.Errorf("unexpected state: %d", c.state)
+	}
+
+	c.state = processing
+
 	ctx, c.cancel = context.WithCancel(ctx)
 
 	if err := c.establish(); err != nil {
@@ -62,6 +83,8 @@ func (c *Client) Register(ctx context.Context, id uuid.UUID) error {
 		c.cancel()
 		return fmt.Errorf("failed to handle register: %w", err)
 	}
+
+	c.state = registered
 
 	c.wg.Add(2)
 
@@ -100,6 +123,15 @@ func (c *Client) Register(ctx context.Context, id uuid.UUID) error {
 // This function initializes the client and handles the bind operation.
 // It returns an error if the client initialization or bind operation fails.
 func (c *Client) Bind(id uuid.UUID) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.state != connected {
+		return fmt.Errorf("unexpected state: %d", c.state)
+	}
+
+	c.state = processing
+
 	if err := c.establish(); err != nil {
 		return fmt.Errorf("failed to init client: %w", err)
 	}
@@ -108,6 +140,8 @@ func (c *Client) Bind(id uuid.UUID) error {
 		return fmt.Errorf("failed to handle bind: %w", err)
 	}
 
+	c.state = bound
+
 	return nil
 }
 
@@ -115,6 +149,13 @@ func (c *Client) Bind(id uuid.UUID) error {
 // It cancels any pending requests and waits for all pending requests to complete before closing the connection.
 // Returns an error if there was a problem closing the connection.
 func (c *Client) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.state == disconnected {
+		return nil
+	}
+
 	defer c.wg.Wait()
 
 	if c.cancel == nil {
@@ -122,6 +163,8 @@ func (c *Client) Close() error {
 	}
 
 	c.cancel()
+
+	c.state = disconnected
 
 	return c.conn.Close()
 }

--- a/proto/server.go
+++ b/proto/server.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"sync/atomic"
+	"sync"
 
 	"github.com/google/uuid"
 )
@@ -26,17 +26,17 @@ type ServerOption func(*Server)
 type Server struct {
 	conn         net.Conn
 	userPassAuth func(username, password string) bool
-	state        atomic.Int32
+	state        State
 	id           uuid.UUID
 	noAuth       bool
+	mu           sync.RWMutex
 }
 
 // NewServer creates a new Server instance with the given net.Conn.
 // It initializes the Server's state to 0 and sets the connection to the provided conn.
 func NewServer(conn net.Conn, opts ...ServerOption) *Server {
 	s := &Server{
-		state: atomic.Int32{},
-		conn:  conn,
+		conn: conn,
 	}
 
 	for _, opt := range opts {
@@ -52,7 +52,10 @@ func NewServer(conn net.Conn, opts ...ServerOption) *Server {
 
 // State returns the current state of the server.
 func (s *Server) State() State {
-	return State(s.state.Load())
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.state
 }
 
 // ID returns the ID of binded connection.
@@ -66,9 +69,14 @@ func (s *Server) ID() uuid.UUID {
 // If any error occurs during the process, it closes the connection and returns an error.
 // Returns nil if the process is successful.
 func (s *Server) Process() error {
-	if !s.state.CompareAndSwap(int32(StateConnected), int32(StateProcessing)) {
-		return fmt.Errorf("unexpected state: %d", s.state.Load())
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.state != StateConnected {
+		return fmt.Errorf("unexpected state: %d", s.state)
 	}
+
+	s.state = StateProcessing
 
 	if err := s.handleInit(); err != nil {
 		_ = s.conn.Close()
@@ -89,8 +97,11 @@ func (s *Server) Process() error {
 // It returns an error if any of the operations fail, such as writing to the connection,
 // reading the response, or encountering unexpected states or versions.
 func (s *Server) SendConnectCommand(id uuid.UUID) error {
-	if s.state.Load() != int32(StateRegistered) {
-		return fmt.Errorf("unexpected state: %d", s.state.Load())
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.state != StateRegistered {
+		return fmt.Errorf("unexpected state: %d", s.state)
 	}
 
 	req := make([]byte, 0, 17)
@@ -113,8 +124,11 @@ func (s *Server) SendConnectCommand(id uuid.UUID) error {
 // It returns nil if the server responds successfully or an error if the operation fails.
 // An error is returned if the server is not in the registered state, the request fails, or the response is unsuccessful.
 func (s *Server) SendPingCommand() error {
-	if s.state.Load() != int32(StateRegistered) {
-		return fmt.Errorf("unexpected state: %d", s.state.Load())
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.state != StateRegistered {
+		return fmt.Errorf("unexpected state: %d", s.state)
 	}
 
 	req := make([]byte, 0, 17)
@@ -135,7 +149,10 @@ func (s *Server) SendPingCommand() error {
 // Close closes the server connection and updates the server state to "Disconnected".
 // It returns an error if there was a problem closing the connection.
 func (s *Server) Close() error {
-	s.state.Store(int32(StateDisconnected))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.state = StateDisconnected
 
 	return s.conn.Close()
 }
@@ -291,9 +308,11 @@ func (s *Server) handleRegister() error {
 		return fmt.Errorf("failed to write register response: %w", err)
 	}
 
-	if !s.state.CompareAndSwap(int32(StateProcessing), int32(StateRegistered)) {
-		return fmt.Errorf("unexpected state: %d", s.state.Load())
+	if s.state != StateProcessing {
+		return fmt.Errorf("unexpected state: %d", s.state)
 	}
+
+	s.state = StateRegistered
 
 	return nil
 }
@@ -321,9 +340,11 @@ func (s *Server) handleBind() error {
 		return fmt.Errorf("failed to write bind response: %w", err)
 	}
 
-	if !s.state.CompareAndSwap(int32(StateProcessing), int32(StateBound)) {
-		return fmt.Errorf("unexpected state: %d", s.state.Load())
+	if s.state != StateProcessing {
+		return fmt.Errorf("unexpected state: %d", s.state)
 	}
+
+	s.state = StateBound
 
 	return nil
 }


### PR DESCRIPTION
### Description

This pull request introduces robust state management for both the Client and Server components. 

- **Client Updates**: Implemented a `clientState` type with mutex protection to manage state transitions securely. Updated `Register`, `Bind`, and `Close` methods to validate and handle state changes effectively, preventing invalid operations and enhancing lifecycle management.

- **Server Updates**: Replaced `atomic.Int32` with a new `State` type and `sync.RWMutex` for better thread safety and code clarity. Updated all relevant methods to leverage this new locking mechanism to ensure consistent behavior in state transitions.

These changes improve the overall reliability and maintainability of both Client and Server state management. 

