### PR TITLE
Refactor connection handling and improve context management

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -187,7 +187,23 @@ func (d *Dialer) serve(ctx context.Context) {
 	}
 }
 
-func (d *Dialer) handleConnection(_ context.Context, conn net.Conn) {
+// handleConnection manages a single incoming connection and processes its state.
+// It takes ctx of type context.Context for managing the lifecycle of the operation and conn of type net.Conn for the connection.
+// It does not return any value. If an error occurs during state processing, the connection is closed or ignored.
+// It handles different states (Registered, Bound) and adds or removes connections to/from the connection manager.
+func (d *Dialer) handleConnection(ctx context.Context, conn net.Conn) {
+	done := make(chan struct{})
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
+
 	s := proto.NewServer(conn, d.serverOpts...)
 	if err := s.Process(); err != nil {
 		return
@@ -196,25 +212,28 @@ func (d *Dialer) handleConnection(_ context.Context, conn net.Conn) {
 	switch s.State() {
 	case proto.StateRegistered:
 		d.cm.AddConnection(s)
+		close(done)
+		return
 
 	case proto.StateBound:
 		id := s.ID()
 		req := d.removeRequest(id)
 
 		if req == nil {
-			_ = s.Close()
 			return
 		}
 
 		select {
 		case req.ch <- conn:
+			close(done)
+			return
 		case <-req.ctx.Done():
-			_ = s.Close()
+			return
 		}
 
 	default:
 		slog.Error("unexpected state while handling incomming connection", slog.Any("state", s.State()))
-		_ = s.Close()
+		return
 	}
 }
 

--- a/dialer.go
+++ b/dialer.go
@@ -169,41 +169,52 @@ func (d *Dialer) SendEvent(_ context.Context, name string, payload any) error {
 // It does not return any values directly but terminates if the listener is closed or ctx is canceled.
 // It stops processing a connection in case of errors during its handling.
 func (d *Dialer) serve(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	var wg sync.WaitGroup
 	for {
 		conn, err := d.listener.Accept()
 		if err != nil {
+			cancel()
 			return
 		}
 
-		s := proto.NewServer(conn, d.serverOpts...)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.handleConnection(ctx, conn)
+		}()
+	}
+}
 
-		if err := s.Process(); err != nil {
-			continue
+func (d *Dialer) handleConnection(_ context.Context, conn net.Conn) {
+	s := proto.NewServer(conn, d.serverOpts...)
+	if err := s.Process(); err != nil {
+		return
+	}
+
+	switch s.State() {
+	case proto.StateRegistered:
+		d.cm.AddConnection(s)
+
+	case proto.StateBound:
+		id := s.ID()
+		req := d.removeRequest(id)
+
+		if req == nil {
+			_ = s.Close()
+			return
 		}
 
-		switch s.State() {
-		case proto.StateRegistered:
-			d.cm.AddConnection(s)
-
-		case proto.StateBound:
-			id := s.ID()
-			req := d.removeRequest(id)
-
-			if req == nil {
-				_ = s.Close()
-				continue
-			}
-
-			select {
-			case req.ch <- conn:
-			case <-req.ctx.Done():
-				_ = s.Close()
-			}
-
-		default:
-			slog.ErrorContext(ctx, "unexpected state while handling incomming connection", slog.Any("state", s.State()))
+		select {
+		case req.ch <- conn:
+		case <-req.ctx.Done():
 			_ = s.Close()
 		}
+
+	default:
+		slog.Error("unexpected state while handling incomming connection", slog.Any("state", s.State()))
+		_ = s.Close()
 	}
 }
 

--- a/dialer.go
+++ b/dialer.go
@@ -235,7 +235,7 @@ func (d *Dialer) handleConnection(ctx context.Context, conn net.Conn) {
 		}
 
 	default:
-		slog.Error("unexpected state while handling incomming connection", slog.Any("state", s.State()))
+		slog.Error("unexpected state while handling incoming connection", slog.Any("state", s.State()))
 		return
 	}
 }

--- a/dialer.go
+++ b/dialer.go
@@ -172,6 +172,7 @@ func (d *Dialer) serve(ctx context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	var wg sync.WaitGroup
+
 	for {
 		conn, err := d.listener.Accept()
 		if err != nil {
@@ -180,6 +181,7 @@ func (d *Dialer) serve(ctx context.Context) {
 		}
 
 		wg.Add(1)
+
 		go func() {
 			defer wg.Done()
 			d.handleConnection(ctx, conn)
@@ -194,6 +196,7 @@ func (d *Dialer) serve(ctx context.Context) {
 func (d *Dialer) handleConnection(ctx context.Context, conn net.Conn) {
 	done := make(chan struct{})
 	ctx, cancel := context.WithCancel(ctx)
+
 	defer cancel()
 
 	go func() {
@@ -213,8 +216,8 @@ func (d *Dialer) handleConnection(ctx context.Context, conn net.Conn) {
 	case proto.StateRegistered:
 		d.cm.AddConnection(s)
 		close(done)
-		return
 
+		return
 	case proto.StateBound:
 		id := s.ID()
 		req := d.removeRequest(id)

--- a/listener.go
+++ b/listener.go
@@ -17,13 +17,17 @@ type EventHandler func(event Event)
 type Event interface {
 	ParsePayload(v any) error
 }
+
+type dialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
 type Listener struct {
 	ctx           context.Context
 	addr          net.Addr
 	cancel        context.CancelFunc
 	client        *proto.Client
-	dialer        *net.Dialer
-	tlsConfig     *tls.Config
+	dialer        dialer
 	eventHandlers map[proto.CommandType]EventHandler
 	clientOpts    []proto.ClientOption
 }
@@ -56,19 +60,6 @@ func Listen(ctx context.Context, dialerSrv string, opts ...ListenerOption) (*Lis
 	if err != nil {
 		l.cancel()
 		return nil, fmt.Errorf("failed to connect to dialler server: %w", err)
-	}
-
-	if l.tlsConfig != nil {
-		tlsConn := tls.Client(conn, l.tlsConfig)
-		if err := tlsConn.Handshake(); err != nil {
-			_ = conn.Close()
-
-			l.cancel()
-
-			return nil, fmt.Errorf("TLS handshake failed: %w", err)
-		}
-
-		conn = tlsConn
 	}
 
 	l.client = proto.NewClient(conn, l.clientOpts...)
@@ -107,16 +98,6 @@ func (l *Listener) Accept() (net.Conn, error) {
 				if err != nil {
 					l.cancel()
 					return nil, fmt.Errorf("failed to connect to dialler server: %w", err)
-				}
-
-				if l.tlsConfig != nil {
-					tlsConn := tls.Client(conn, l.tlsConfig)
-					if err := tlsConn.Handshake(); err != nil {
-						_ = conn.Close()
-						return nil, fmt.Errorf("TLS handshake failed: %w", err)
-					}
-
-					conn = tlsConn
 				}
 
 				client := proto.NewClient(conn, l.clientOpts...)
@@ -174,7 +155,11 @@ func WithUserPass(username, password string) (ListenerOption, error) {
 // If this option is not provided, the connection will be unencrypted.
 func WithListenerTLSConfig(config *tls.Config) ListenerOption {
 	return func(l *Listener) {
-		l.tlsConfig = config.Clone() // Clone to prevent external modifications
+		d := l.dialer.(*net.Dialer)
+		l.dialer = &tls.Dialer{
+			NetDialer: d,
+			Config:    config.Clone(),
+		}
 	}
 }
 

--- a/listener.go
+++ b/listener.go
@@ -102,7 +102,7 @@ func (l *Listener) Accept() (net.Conn, error) {
 
 				client := proto.NewClient(conn, l.clientOpts...)
 
-				if err := client.Bind(id); err != nil {
+				if err := client.Bind(l.ctx, id); err != nil {
 					_ = conn.Close()
 					return nil, fmt.Errorf("failed to bind connection: %w", err)
 				}
@@ -155,7 +155,7 @@ func WithUserPass(username, password string) (ListenerOption, error) {
 // If this option is not provided, the connection will be unencrypted.
 func WithListenerTLSConfig(config *tls.Config) ListenerOption {
 	return func(l *Listener) {
-		d := l.dialer.(*net.Dialer)
+		d, _ := l.dialer.(*net.Dialer)
 		l.dialer = &tls.Dialer{
 			NetDialer: d,
 			Config:    config.Clone(),

--- a/proto/client.go
+++ b/proto/client.go
@@ -73,6 +73,15 @@ func (c *Client) Register(ctx context.Context, id uuid.UUID) error {
 
 	ctx, c.cancel = context.WithCancel(ctx)
 
+	c.wg.Add(1)
+
+	go func() {
+		defer c.wg.Done()
+		<-ctx.Done()
+
+		_ = c.conn.Close()
+	}()
+
 	if err := c.establish(); err != nil {
 		c.cancel()
 		return fmt.Errorf("failed to init client: %w", err)
@@ -85,14 +94,7 @@ func (c *Client) Register(ctx context.Context, id uuid.UUID) error {
 
 	c.state = registered
 
-	c.wg.Add(2)
-
-	go func() {
-		defer c.wg.Done()
-		<-ctx.Done()
-
-		_ = c.conn.Close()
-	}()
+	c.wg.Add(1)
 
 	go func() {
 		defer c.wg.Done()
@@ -121,7 +123,7 @@ func (c *Client) Register(ctx context.Context, id uuid.UUID) error {
 // The ID parameter represents the identifier used for binding.
 // This function initializes the client and handles the bind operation.
 // It returns an error if the client initialization or bind operation fails.
-func (c *Client) Bind(id uuid.UUID) error {
+func (c *Client) Bind(ctx context.Context, id uuid.UUID) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -130,6 +132,16 @@ func (c *Client) Bind(id uuid.UUID) error {
 	}
 
 	c.state = processing
+
+	ctx, c.cancel = context.WithCancel(ctx)
+
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		<-ctx.Done()
+
+		_ = c.conn.Close()
+	}()
 
 	if err := c.establish(); err != nil {
 		return fmt.Errorf("failed to init client: %w", err)

--- a/proto/client.go
+++ b/proto/client.go
@@ -132,10 +132,10 @@ func (c *Client) Bind(ctx context.Context, id uuid.UUID) error {
 	}
 
 	c.state = processing
-
 	ctx, c.cancel = context.WithCancel(ctx)
 
 	c.wg.Add(1)
+
 	go func() {
 		defer c.wg.Done()
 		<-ctx.Done()

--- a/proto/proto_int_test.go
+++ b/proto/proto_int_test.go
@@ -146,7 +146,7 @@ func TestSendCommand_Failure(t *testing.T) {
 		close(done)
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 	defer cancel()
 
 	err := client.Register(ctx, uuid.New())
@@ -186,7 +186,7 @@ func TestBind_Success(t *testing.T) {
 		close(done)
 	}()
 
-	err := client.Bind(expectedID)
+	err := client.Bind(t.Context(), expectedID)
 	assert.NoError(t, err)
 
 	select {
@@ -217,7 +217,7 @@ func TestBind_Failure(t *testing.T) {
 		close(done)
 	}()
 
-	err := client.Bind(uuid.New())
+	err := client.Bind(t.Context(), uuid.New())
 	assert.Error(t, err)
 
 	select {


### PR DESCRIPTION
### Summary

This pull request introduces significant refactoring of connection handling and context management:

- Unified context handling by introducing `ctx` to `Bind` and consolidating connection teardown logic into a single goroutine, ensuring proper resource cleanup.
- Replaced manual TLS handshake logic with `tls.Dialer`, simplifying and standardizing TLS connection handling.
- Implemented context-based cancellation for connections, preventing goroutine leaks and ensuring efficient resource management.
- Encapsulated connection logic with `handleConnection`, improving readability and modularity. Leveraged a wait group to efficiently manage connection lifecycle.